### PR TITLE
Add trinket keybinds for servers without support

### DIFF
--- a/Bindings.xml
+++ b/Bindings.xml
@@ -9,4 +9,9 @@
     <Binding name="GLADDYBUTTON3_RIGHT"/>
     <Binding name="GLADDYBUTTON4_RIGHT"/>
     <Binding name="GLADDYBUTTON5_RIGHT"/>
+	<Binding header="GLADDY" name="GLADDYTRINKET1" />
+	<Binding name="GLADDYTRINKET2" />
+	<Binding name="GLADDYTRINKET3" />
+	<Binding name="GLADDYTRINKET4" />
+	<Binding name="GLADDYTRINKET5" />
 </Bindings>

--- a/Frame.lua
+++ b/Frame.lua
@@ -105,6 +105,25 @@ function Gladdy:CreateFrame()
     self.frame:Hide()
 end
 
+local function StyleActionButton(f)
+    local name = f:GetName()
+    local button  = _G[name]
+    local icon  = _G[name .. "Icon"]
+    local normalTex = _G[name .. "NormalTexture"]
+
+    normalTex:SetHeight(button:GetHeight())
+    normalTex:SetWidth(button:GetWidth())
+    normalTex:SetPoint("CENTER")
+
+    button:SetNormalTexture("Interface\\AddOns\\Gladdy\\Images\\Gloss")
+
+    icon:SetTexCoord(.1, .9, .1, .9)
+    icon:SetPoint("TOPLEFT", button, "TOPLEFT", 2, -2)
+    icon:SetPoint("BOTTOMRIGHT", button, "BOTTOMRIGHT", -2, 2)
+
+    normalTex:SetVertexColor(1, 1, 1, 1)
+end
+
 function Gladdy:UpdateFrame()
     local teamSize = self.curBracket or 5
 
@@ -194,9 +213,16 @@ function Gladdy:UpdateFrame()
 		-- Cooldown frame
 		if (self.db.cooldown) then
 			button.spellCooldownFrame:ClearAllPoints()
-			button.spellCooldownFrame:SetPoint("TOPLEFT", button,"TOPRIGHT", iconSize+5, 1) -- needs to be properly anchored after trinket
-			button.spellCooldownFrame:SetHeight(self.db.healthBarHeight+extraBarHeight)
-			button.spellCooldownFrame:SetWidth(self.db.healthBarHeight+extraBarHeight)
+			if self.db.cooldownPos == "RIGHT" then
+				button.spellCooldownFrame:SetPoint("TOPLEFT", button,"TOPRIGHT", iconSize+5, 1) -- needs to be properly anchored after trinket
+				
+			else
+				button.spellCooldownFrame:SetPoint("TOPRIGHT",button,"TOPLEFT",-5,-1)
+			end
+			--button.spellCooldownFrame:SetHeight(self.db.healthBarHeight+extraBarHeight)
+			button.spellCooldownFrame:SetHeight(self.db.cooldownSize*4)
+			--button.spellCooldownFrame:SetWidth(self.db.healthBarHeight+extraBarHeight)
+			button.spellCooldownFrame:SetWidth(self.db.cooldownSize*4)
 			button.spellCooldownFrame:Show()
          -- Update each cooldown icon
          for i=1,14 do
@@ -204,7 +230,7 @@ function Gladdy:UpdateFrame()
             icon:SetHeight(button.spellCooldownFrame:GetHeight()/2)
             icon:SetWidth(button.spellCooldownFrame:GetWidth()/2)
             icon:ClearAllPoints()
-            
+            if(self.db.cooldownPos == "RIGHT") then
 					if(i==1) then
 						icon:SetPoint("TOPLEFT",button.spellCooldownFrame)
 					elseif(i==2) then
@@ -212,17 +238,25 @@ function Gladdy:UpdateFrame()
 					elseif(i>=3) then
 						icon:SetPoint("LEFT",button.spellCooldownFrame["icon"..i-2],"RIGHT",1,0)
 					end
+				else
+					if(i==1) then
+						icon:SetPoint("TOPRIGHT",button.spellCooldownFrame)
+					elseif(i==2) then
+						icon:SetPoint("TOP",button.spellCooldownFrame["icon"..i-1],"BOTTOM",0,-1)
+					elseif(i>=3) then
+						icon:SetPoint("RIGHT",button.spellCooldownFrame["icon"..i-2],"LEFT",-1,0)
+					end
+				end	
 				
 				if (icon.active) then
                icon.active = false
                icon.cooldown:SetCooldown(GetTime(), 0)
                icon:SetScript("OnUpdate", nil)            
             end
-            
             icon.spellId = nil            
             icon:SetAlpha(1)
             icon.texture:SetTexture("Interface\\Icons\\Spell_Holy_PainSupression")
-            --StyleActionButton(icon)
+            StyleActionButton(icon)
             
             if (not self.frame.testing) then
                icon:Hide()

--- a/Frame.lua
+++ b/Frame.lua
@@ -36,6 +36,8 @@ function Gladdy:CreateFrame()
     self.frame:EnableMouse(true)
     self.frame:SetMovable(true)
     self.frame:RegisterForDrag("LeftButton")
+	
+	
     self.frame:SetScript("OnDragStart", function(f)
         if (not InCombatLockdown() and not self.db.locked) then
             f:StartMoving()
@@ -232,6 +234,14 @@ function Gladdy:CreateButton(i)
 
     local button = CreateFrame("Frame", "GladdyButtonFrame" .. i, self.frame)
     button:SetAlpha(0)
+	
+	-- Trinket presser
+    local trinketButton = CreateFrame("Button", "GladdyTrinketButton" .. i, button, "SecureActionButtonTemplate")
+    trinketButton:RegisterForClicks("AnyUp")
+    trinketButton:SetAttribute("*type*", "macro")
+    --trinketButton:SetAttribute("macrotext1", string.format("/script Gladdy:TrinketUsed(\"%s\")", "arena" .. i))
+	-- Is there a way to NOT use a global function?
+	trinketButton:SetAttribute("macrotext1", string.format("/script Trinket:Used(\"%s\")", "arena" .. i))
 
     local secure = CreateFrame("Button", "GladdyButton" .. i, button, "SecureActionButtonTemplate")
     secure:RegisterForClicks("AnyUp")
@@ -240,6 +250,7 @@ function Gladdy:CreateButton(i)
     button.id = i
     button.unit = "arena" .. i
     button.secure = secure
+	button.trinketButton = trinketButton
 
     for k, v in pairs(self.BUTTON_DEFAULTS) do
         button[k] = v

--- a/Gladdy.lua
+++ b/Gladdy.lua
@@ -160,8 +160,6 @@ function Gladdy:OnInitialise()
     self.dbi.RegisterCallback(self, "OnProfileCopied", "OnProfileChanged")
     self.dbi.RegisterCallback(self, "OnProfileReset", "OnProfileChanged")
     self.db = self.dbi.profile
-	self.db.cooldown = true
-	self.db.cooldownPos = "TOP"
 
     self.LSM = LibStub("LibSharedMedia-3.0")
     self.LSM:Register("statusbar", "Gloss", "Interface\\AddOns\\Gladdy\\Images\\Gloss")
@@ -176,7 +174,6 @@ function Gladdy:OnInitialise()
         ["arena4"] = {name = "Talmon", raceLoc = L["Human"], classLoc = L["Warlock"], class = "WARLOCK", health = 10221, healthMax = 14960, power = 9855, powerMax = 9855, powerType = 0, spec = L["Demonology"]},
         ["arena5"] = {name = "Hydra", raceLoc = L["Undead"], classLoc = L["Priest"], class = "PRIEST", health = 11960, healthMax = 11960, power = 2515, powerMax = 10240, powerType = 0, spec = L["Discipline"]},
     }
-
     self.specBuffs = self:GetSpecBuffs()
     self.specSpells = self:GetSpecSpells()
 	

--- a/Gladdy.toc
+++ b/Gladdy.toc
@@ -24,3 +24,4 @@ Modules\Highlight.lua
 Modules\Nameplates.lua
 Modules\Powerbar.lua
 Modules\Trinket.lua
+Modules\Cooldowns.lua

--- a/Modules/Announcements.lua
+++ b/Modules/Announcements.lua
@@ -148,7 +148,7 @@ function Announcements:Send(msg, throttle, color)
     elseif (dest == "rw") then
         RaidNotice_AddMessage(RaidBossEmoteFrame, msg, color)
     elseif (dest == "fct" and IsAddOnLoaded("Blizzard_CombatText")) then
-        CombatText_AddMessage(msg, COMBAT_TEXT_SCROLL_FUNCTION, color.r, color.g, color.b)
+        CombatText_AddMessage(msg, COMBAT_TEXT_SCROLL_FUNCTION, color.r, color.g, color.b, "crit")
     elseif (dest == "msbt" and IsAddOnLoaded("MikScrollingBattleText")) then
         MikSBT.DisplayMessage(msg, MikSBT.DISPLAYTYPE_NOTIFICATION, true, color.r * 255, color.g * 255, color.b * 255)
     elseif (dest == "sct" and IsAddOnLoaded("sct")) then

--- a/Modules/Clicks.lua
+++ b/Modules/Clicks.lua
@@ -34,6 +34,12 @@ BINDING_NAME_GLADDYBUTTON2_RIGHT = L["Right Click Enemy 2"]
 BINDING_NAME_GLADDYBUTTON3_RIGHT = L["Right Click Enemy 3"]
 BINDING_NAME_GLADDYBUTTON4_RIGHT = L["Right Click Enemy 4"]
 BINDING_NAME_GLADDYBUTTON5_RIGHT = L["Right Click Enemy 5"]
+BINDING_NAME_GLADDYTRINKET1 = L["Trinket Used Enemy 1"]
+BINDING_NAME_GLADDYTRINKET2 = L["Trinket Used Enemy 2"]
+BINDING_NAME_GLADDYTRINKET3 = L["Trinket Used Enemy 3"]
+BINDING_NAME_GLADDYTRINKET4 = L["Trinket Used Enemy 4"]
+BINDING_NAME_GLADDYTRINKET5 = L["Trinket Used Enemy 5"]
+
 
 function Clicks:Initialise()
     self:RegisterMessage("JOINED_ARENA")
@@ -56,7 +62,9 @@ function Clicks:JOINED_ARENA()
     for k, v in pairs(Gladdy.buttons) do
         local left = GetBindingKey(("GLADDYBUTTON%d_LEFT"):format(v.id))
         local right = GetBindingKey(("GLADDYBUTTON%d_RIGHT"):format(v.id))
-
+		local key = GetBindingKey("GLADDYTRINKET" .. v.id)
+		
+		ClearOverrideBindings(v.trinketButton)
         ClearOverrideBindings(v.secure)
 
         if (left) then
@@ -65,6 +73,10 @@ function Clicks:JOINED_ARENA()
 
         if (right) then
             SetOverrideBindingClick(v.secure, false, right, v.secure:GetName(), "RightButton")
+        end
+		
+		if (key) then
+            SetOverrideBindingClick(v.trinketButton, true, key, v.trinketButton:GetName(), "LeftButton")
         end
     end
 

--- a/Modules/Cooldowns.lua
+++ b/Modules/Cooldowns.lua
@@ -1,0 +1,168 @@
+local Gladdy = LibStub("Gladdy")
+local L = Gladdy.L
+
+function Gladdy:GetCooldownList()
+	return {
+		-- Spell Name			   Cooldown[, Spec]
+		-- Mage
+		["MAGE"] = {
+         [1953] 	= 15,    -- Blink
+         --[122] 	= 25,    -- Frost Nova
+         [2139] 	= 24,    -- Counterspell
+         [45438] 	= 300,   -- Ice Block
+         [12472] 	= { cd = 180, spec = L["Frost"], },    -- Icy Veins
+         [31687] 	= { cd = 180, spec = L["Frost"], },    -- Summon Water Elemental    
+         [12043] 	= { cd = 120, spec = L["Arcane"], },   -- Presence of Mind
+         [11129] 	= { cd = 120, spec = L["Fire"] },      -- Combustion
+         [12042] 	= { cd = 120, spec = L["Arcane"], },   -- Arcane Power  
+         [11958] 	= { cd = 480, spec = L["Frost"],       -- Coldsnap
+            resetCD = { 
+               [12472] = true, 
+               [45438] = true, 
+               [42917] = true,
+               [31687] = true,  
+            }, 
+         },        
+      },
+      		
+		-- Priest
+		["PRIEST"] = {
+         [10890] 	= { cd = 27, [L["Shadow"]] = 23, },    -- Psychic Scream  
+         [34433] 	= { cd = 300, [L["Shadow"]] = 180, },  -- Shadowfiend
+         [15487] 	= { cd = 45, spec = L["Shadow"], },    -- Silence
+         [10060] 	= { cd = 120, spec = L["Discipline"], }, -- Power Infusion
+         [33206] 	= { cd = 180, spec = L["Discipline"], }, -- Pain Suppression
+      },
+		
+		-- Druid
+		["DRUID"] = {
+         [22812] 	= 60,    -- Barkskin
+         [29166] 	= 360,   -- Innervate
+         [8983] 	= 60,    -- Bash
+         [16689] 	= 60,    -- Natures Grasp
+         [17116] 	= { cd = 120, spec = L["Restoration"], } , -- Natures Swiftness
+         [33831] 	= { cd = 180, spec = L["Balance"], },  -- Force of Nature
+      },
+		
+		-- Shaman
+		["SHAMAN"] = {
+		[8042] 	= { cd = 6,                              -- Earth Shock
+            sharedCD = {
+               [8056] = true,       -- Frost Shock
+               [8050] = true,       -- Flame Shock
+            },
+         },
+         [30823] 	= { cd = 60, spec = L["Enhancement"], }, -- Shamanistic Rage
+         [16166] 	= { cd = 180, spec = L["Elemental"], },  -- Elemental Mastery
+         [16188] 	= { cd = 120, spec = L["Restoration"], }, -- Natures Swiftness		 
+         [16190] 	= { cd = 300, spec = L["Restoration"], }, -- Mana Tide Totem             
+      },
+      
+      -- Paladin
+      ["PALADIN"] = {
+         [10278] 	= 180,   -- Blessing of Protection
+         [1044] 	= 25,    -- Blessing of Freedom 
+         [10308] 	= { cd = 60, [L["Retribution"]] = 40, },   -- Hammer of Justice
+         [642] 	= { cd = 300,                             -- Divine Shield
+            sharedCD = {
+               cd = 60,										-- no actual shared CD but debuff
+               [31884] = true,
+            },
+         },
+         [31884] 	= { cd = 180, spec = L["Retribution"],                  -- Avenging Wrath
+            sharedCD = {
+               cd = 60,
+               [642] = true,
+            },
+         },         
+         [20066] 	= { cd = 60, spec = L["Retribution"], },  -- Repentance
+         [31842] 	= { cd = 180, spec = L["Holy"], },        -- Divine Illumination
+         [31935] 	= { cd = 30, spec = L["Protection"], },   -- Avengers Shield
+                                  
+      }, 
+      
+      -- Warlock
+      ["WARLOCK"] = {
+         [17928] 	= 40,    -- Howl of Terror
+         [27223] 	= 120,   -- Death Coil         
+         [19647] 	= { cd = 24 },	-- Spell Lock; how will I handle pet spells?      
+         [30414] 	= { cd = 20, spec = L["Destruction"], },  -- Shadowfury               
+      },  
+      
+      -- Warrior
+      ["WARRIOR"] = {
+         --[[6552] 	= { cd = 10,                              -- Pummel
+            sharedCD = {
+               [72] = true,
+            },
+         },
+         [72] 	   = { cd = 12,                              -- Shield Bash
+            sharedCD = {
+               [6552] = true,
+            },
+         }, ]]        
+         [23920] 	= 10,    -- Spell Reflection
+         [3411] 	= 30,    -- Intervene
+         [676] 	= 60,    -- Disarm       
+         [5246] 	= 120,   -- Intimidating Shout 
+         --[2565] 	= 60,    -- Shield Block              
+         [12292] 	= { cd = 180, spec = L["Arms"], },        -- Death Wish             
+         [12975] 	= { cd = 180, },  -- Last Stand         
+         [12809] 	= { cd = 30, spec = L["Protection"], },   -- Concussion Blow
+         
+      },
+      
+      -- Hunter
+      ["HUNTER"] = {
+         [19503] 	= 30,    -- Scatter Shot
+         [19263] 	= { cd = 90, spec = L["Survival"], },    -- Deterrence
+		 [19263] 	= { cd = 90, spec = L["Marksmanship"], },    -- Deterrence
+         [14311] 	= { cd = 30,                              -- Freezing Trap
+            sharedCD = {
+               [13809] = true,       -- Frost Trap
+               [34600] = true,       -- Snake Trap
+            },
+         },
+         [13809] 	= { cd = 30,                              -- Frost Trap
+            sharedCD = {
+               [14311] = true,       -- Freezing Trap
+               [34600] = true,       -- Snake Trap
+            },
+         },
+         [34600] 	= { cd = 30,                              -- Snake Trap
+            sharedCD = {
+               [14311] = true,       -- Freezing Trap
+               [13809] = true,       -- Frost Trap
+            },
+         },
+         [34490] 	= { cd = 20, spec = L["Marksmanship"], }, -- Silencing Shot
+         [19386] 	= { cd = 60, spec = L["Survival"], },     -- Wyvern Sting       
+         [19577] 	= { cd = 60, spec = L["Beast Mastery"],  }, -- Intimidation
+         [38373] 	= { cd = 120, spec = L["Beast Mastery"], }, -- The Beast Within
+      },
+      
+      -- Rogue
+      ["ROGUE"] = {
+         --[1766] 	= 10,    -- Kick
+         [8643] 	= 20,    -- Kidney Shot
+         [26669] 	= { cd = 300, [L["Combat"]] = 180,},   -- Evasion
+         [31224] 	= 60,    -- Cloak of Shadow
+         [26889] 	= { cd = 300, [L["Subtlety"]] = 180,},   -- Vanish        
+         [2094] 	= { cd = 180, [L["Subtlety"]] = 90,},    -- Blind
+         --[11305] 	= 180,   -- Sprint
+         [14177] 	= { cd = 180, spec = L["Assassination"], }, -- Cold Blood
+         [13750] 	= { cd = 180, spec = L["Combat"], },      -- Adrenaline Rush
+         [13877] 	= { cd = 120, spec = L["Combat"], },      -- Blade Flurry
+         [36554] 	= { cd = 30, spec = L["Subtlety"], },     -- Shadowstep
+         [14185] 	= { cd = 600, spec = L["Subtlety"],       -- Preparation
+            resetCD = {
+               [26669] = true,
+               [11305] = true,
+               [26889] = true,
+               [14177] = true,
+               [36554] = true,
+            },
+         },
+      },                        
+	}
+end

--- a/Modules/Cooldowns.lua
+++ b/Modules/Cooldowns.lua
@@ -8,7 +8,7 @@ local Cooldown = Gladdy:NewModule("Cooldown", nil, {
 })
 
 function Cooldown:Test(unit)
-		local button = Gladdy.buttons[unit]
+		--[[local button = Gladdy.buttons[unit]
 		self.cooldownSpells = Gladdy:GetCooldownList()
 		button.lastCooldownSpell = 1
 		local class = "WARRIOR"
@@ -20,7 +20,7 @@ function Cooldown:Test(unit)
 			icon.texture:SetTexture(Gladdy.spellTextures[k])
 			button.spellCooldownFrame["icon" .. button.lastCooldownSpell] = icon
 			button.lastCooldownSpell = button.lastCooldownSpell + 1  
-		end
+		end]]
 end
 
 local function option(params)
@@ -243,7 +243,7 @@ function Gladdy:GetCooldownList()
             },
          },
       },
-	  ["Scourge"] = {
+	["Scourge"] = {
 		[7744] = 120, -- Will of the Forsaken
 	},
 	["BloodElf"] = {
@@ -259,21 +259,21 @@ function Gladdy:GetCooldownList()
 		
 	},
 	["NightElf"] = {
-		[2651] = { cd = 180, spec = ["Discipline"], },
+		[2651] = { cd = 180, spec = L["Discipline"], }, -- Elune's Grace
+		[10797] = { cd = 30, spec = L["Discipline"], }, -- Star Shards
 	},
 	["Draenei"] = {
-		[32548] = { cd = 300, spec = ["Discipline"], },
+		[32548] = { cd = 300, spec = L["Discipline"], }, -- Hymn of Hope
 	},
 	["Human"] = {
-		[13908] = { cd = 600, spec = ["Discipline"], },
+		[13908] = { cd = 600, spec = L["Discipline"], }, -- Desperate Prayer
 	},
 	["Gnome"] = {
-		[20589] = 105,
+		[20589] = 105, -- Escape Artist
 	},
 	["Dwarf"] = {
 		[20594] = 180, -- Stoneform
-		[13908] = { cd = 600, spec = ["Discipline"], },
-		
+		[13908] = { cd = 600, spec = L["Discipline"], }, -- Desperate Prayer
 	},		
 	}
 end

--- a/Modules/Cooldowns.lua
+++ b/Modules/Cooldowns.lua
@@ -115,8 +115,7 @@ function Gladdy:GetCooldownList()
       -- Hunter
       ["HUNTER"] = {
          [19503] 	= 30,    -- Scatter Shot
-         [19263] 	= { cd = 90, spec = L["Survival"], },    -- Deterrence
-		 [19263] 	= { cd = 90, spec = L["Marksmanship"], },    -- Deterrence
+		 [19263] 	= 300,    -- Deterrence; not on BM but can't do 2 specs
          [14311] 	= { cd = 30,                              -- Freezing Trap
             sharedCD = {
                [13809] = true,       -- Frost Trap
@@ -144,7 +143,7 @@ function Gladdy:GetCooldownList()
       -- Rogue
       ["ROGUE"] = {
          --[1766] 	= 10,    -- Kick
-         [8643] 	= 20,    -- Kidney Shot
+         --[8643] 	= 20,    -- Kidney Shot
          [26669] 	= { cd = 300, [L["Combat"]] = 180,},   -- Evasion
          [31224] 	= 60,    -- Cloak of Shadow
          [26889] 	= { cd = 300, [L["Subtlety"]] = 180,},   -- Vanish        
@@ -163,6 +162,36 @@ function Gladdy:GetCooldownList()
                [36554] = true,
             },
          },
-      },                        
+      },
+	  ["Scourge"] = {
+		[7744] = 120, -- Will of the Forsaken
+	},
+	["BloodElf"] = {
+		[28730] = 120, -- Arcane Torrent
+	},
+	["Tauren"] = {
+		[20549] = 120, -- War Stomp
+	},
+	["Orc"] = {
+		
+	},
+	["Troll"] = {
+		
+	},
+	["NightElf"] = {
+		
+	},
+	["Draenei"] = {
+		
+	},
+	["Human"] = {
+		
+	},
+	["Gnome"] = {
+		
+	},
+	["Dwarf"] = {
+		[20594] = 180, -- Stoneform
+	},		
 	}
 end

--- a/Modules/Trinket.lua
+++ b/Modules/Trinket.lua
@@ -6,7 +6,7 @@ local GetTime = GetTime
 
 local Gladdy = LibStub("Gladdy")
 local L = Gladdy.L
-local Trinket = Gladdy:NewModule("Trinket", nil, {
+Trinket = Gladdy:NewModule("Trinket", nil, {
     trinketDisableOmniCC = false,
 })
 LibStub("AceComm-3.0"):Embed(Trinket)
@@ -85,9 +85,11 @@ function Trinket:JOINED_ARENA()
 end
 
 function Trinket:OnCommReceived(prefix, guid)
+	guid = string.lower(guid)
     if (prefix == "GladdyTrinketUsed") then
         for k, v in pairs(Gladdy.buttons) do
-            if (v.guid == guid) then
+		local vguid = string.lower(v.guid)
+            if (vguid == guid) then
                 self:Used(k)
                 break
             end

--- a/Options.lua
+++ b/Options.lua
@@ -20,6 +20,7 @@ Gladdy.defaults = {
         frameColor = {r = 0, g = 0, b = 0, a = .4},
         barWidth = 180,
         bottomMargin = 10,
+		cooldownPos = "RIGHT",
     },
 }
 

--- a/Speclist.lua
+++ b/Speclist.lua
@@ -34,11 +34,13 @@ function Gladdy:GetSpecBuffs()
 
         -- ROGUE
         [GetSpellInfo(36554)] = L["Subtlety"],          -- Shadowstep
+        [GetSpellInfo(31233)] = L["Assassination"],     -- Find Weakness
 
         -- WARLOCK
         [GetSpellInfo(19028)] = L["Demonology"],        -- Soul Link
         [GetSpellInfo(23759)] = L["Demonology"],        -- Master Demonologist
         [GetSpellInfo(30302)] = L["Destruction"],       -- Nether Protection
+        [GetSpellInfo(34935)] = L["Destruction"],       -- Backlash
 
         -- WARRIOR
         [GetSpellInfo(29838)] = L["Arms"],              -- Second Wind

--- a/Speclist.lua
+++ b/Speclist.lua
@@ -15,6 +15,7 @@ function Gladdy:GetSpecBuffs()
         -- HUNTER
         [GetSpellInfo(34692)] = L["Beast Mastery"],     -- The Beast Within
         [GetSpellInfo(20895)] = L["Beast Mastery"],     -- Spirit Bond
+        [GetSpellInfo(34455)] = L["Beast Mastery"],     -- Ferocious Inspiration
 		[GetSpellInfo(27066)] = L["Marksmanship"],      -- Trueshot Aura
 
         -- MAGE
@@ -83,6 +84,7 @@ function Gladdy:GetSpecSpells()
         -- PRIEST
         [GetSpellInfo(10060)] = L["Discipline"],        -- Power Infusion
         [GetSpellInfo(33206)] = L["Discipline"],        -- Pain Suppression
+        [GetSpellInfo(14752)] = L["Discipline"],        -- Divine Spirit
         [GetSpellInfo(33143)] = L["Holy"],              -- Blessed Resilience
         [GetSpellInfo(34861)] = L["Holy"],              -- Circle of Healing
         [GetSpellInfo(15473)] = L["Shadow"],            -- Shadowform

--- a/Speclist.lua
+++ b/Speclist.lua
@@ -16,7 +16,7 @@ function Gladdy:GetSpecBuffs()
         [GetSpellInfo(34692)] = L["Beast Mastery"],     -- The Beast Within
         [GetSpellInfo(20895)] = L["Beast Mastery"],     -- Spirit Bond
         [GetSpellInfo(34455)] = L["Beast Mastery"],     -- Ferocious Inspiration
-		[GetSpellInfo(27066)] = L["Marksmanship"],      -- Trueshot Aura
+		--[GetSpellInfo(27066)] = L["Marksmanship"],      -- Trueshot Aura
 
         -- MAGE
         [GetSpellInfo(33405)] = L["Frost"],             -- Ice Barrier
@@ -24,7 +24,8 @@ function Gladdy:GetSpecBuffs()
         -- PALADIN
         [GetSpellInfo(31836)] = L["Holy"],              -- Light's Grace
         [GetSpellInfo(20375)] = L["Retribution"],       -- Seal of Command
-        [GetSpellInfo(20218)] = L["Retribution"],       -- Sanctity Aura
+        --[GetSpellInfo(20218)] = L["Retribution"],       -- Sanctity Aura
+        [GetSpellInfo(20049)] = L["Retribution"],       -- Sanctity Aura
 
         -- PRIEST
         [GetSpellInfo(15473)] = L["Shadow"],            -- Shadowform
@@ -82,6 +83,7 @@ function Gladdy:GetSpecSpells()
         [GetSpellInfo(27170)] = L["Retribution"],       -- Seal of Command
         [GetSpellInfo(35395)] = L["Retribution"],       -- Crusader Strike
         [GetSpellInfo(20066)] = L["Retribution"],       -- Repentance
+		[GetSpellInfo(20218)] = L["Retribution"],       -- Sanctity Aura
 
         -- PRIEST
         [GetSpellInfo(10060)] = L["Discipline"],        -- Power Infusion

--- a/Speclist.lua
+++ b/Speclist.lua
@@ -15,7 +15,7 @@ function Gladdy:GetSpecBuffs()
         -- HUNTER
         [GetSpellInfo(34692)] = L["Beast Mastery"],     -- The Beast Within
         [GetSpellInfo(20895)] = L["Beast Mastery"],     -- Spirit Bond
-        [GetSpellInfo(34455)] = L["Beast Mastery"],     -- Ferocious Inspiration
+        --[GetSpellInfo(34455)] = L["Beast Mastery"],     -- Ferocious Inspiration
 		--[GetSpellInfo(27066)] = L["Marksmanship"],      -- Trueshot Aura
 
         -- MAGE
@@ -25,7 +25,7 @@ function Gladdy:GetSpecBuffs()
         [GetSpellInfo(31836)] = L["Holy"],              -- Light's Grace
         [GetSpellInfo(20375)] = L["Retribution"],       -- Seal of Command
         --[GetSpellInfo(20218)] = L["Retribution"],       -- Sanctity Aura
-        [GetSpellInfo(20049)] = L["Retribution"],       -- Sanctity Aura
+        [GetSpellInfo(20049)] = L["Retribution"],       -- Vengeance
 
         -- PRIEST
         [GetSpellInfo(15473)] = L["Shadow"],            -- Shadowform

--- a/Speclist.lua
+++ b/Speclist.lua
@@ -6,11 +6,16 @@ local L = Gladdy.L
 function Gladdy:GetSpecBuffs()
     return {
         -- DRUID
-        [GetSpellInfo(24858)] = L["Balance"],           -- Moonkin Form
+        --[GetSpellInfo(24858)] = L["Balance"],         -- Moonkin Form
+		--[GetSpellInfo(17007)] = L["Feral"],             -- Leader of the Pack
+		[GetSpellInfo(33881)] = L["Restoration"],         -- Natural Perfection
+		[GetSpellInfo(16880)] = L["Restoration"],         -- Nature's Grace; Dreamstate spec in TBC equals Restoration
+		[GetSpellInfo(24858)] = L["Restoration"],         -- Moonkin Form; Dreamstate spec in TBC equals Restoration 
 
         -- HUNTER
         [GetSpellInfo(34692)] = L["Beast Mastery"],     -- The Beast Within
-        [GetSpellInfo(20895)] = L["Beast Mastery"],       -- Spirit Bond
+        [GetSpellInfo(20895)] = L["Beast Mastery"],     -- Spirit Bond
+		[GetSpellInfo(27066)] = L["Marksmanship"],      -- Trueshot Aura
 
         -- MAGE
         [GetSpellInfo(33405)] = L["Frost"],             -- Ice Barrier
@@ -18,19 +23,26 @@ function Gladdy:GetSpecBuffs()
         -- PALADIN
         [GetSpellInfo(31836)] = L["Holy"],              -- Light's Grace
         [GetSpellInfo(20375)] = L["Retribution"],       -- Seal of Command
+        [GetSpellInfo(20218)] = L["Retribution"],       -- Sanctity Aura
 
         -- PRIEST
         [GetSpellInfo(15473)] = L["Shadow"],            -- Shadowform
+        [GetSpellInfo(45234)] = L["Discipline"],        -- Focused Will
+        [GetSpellInfo(27811)] = L["Discipline"],        -- Blessed Recovery
+        [GetSpellInfo(33142)] = L["Holy"],       		-- Blessed Resilience
 
         -- ROGUE
         [GetSpellInfo(36554)] = L["Subtlety"],          -- Shadowstep
 
         -- WARLOCK
         [GetSpellInfo(19028)] = L["Demonology"],        -- Soul Link
+        [GetSpellInfo(23759)] = L["Demonology"],        -- Master Demonologist
         [GetSpellInfo(30302)] = L["Destruction"],       -- Nether Protection
 
         -- WARRIOR
         [GetSpellInfo(29838)] = L["Arms"],              -- Second Wind
+        [GetSpellInfo(12292)] = L["Arms"],              -- Death Wish
+		
     }
 end
 
@@ -48,6 +60,7 @@ function Gladdy:GetSpecSpells()
         [GetSpellInfo(34490)] = L["Marksmanship"],      -- Silencing Shot
         [GetSpellInfo(27066)] = L["Marksmanship"],      -- Trueshot Aura
         [GetSpellInfo(27068)] = L["Survival"],          -- Wyvern Sting
+        [GetSpellInfo(19306)] = L["Survival"],          -- Counterattack
 
         -- MAGE
         [GetSpellInfo(12042)] = L["Arcane"],            -- Arcane Power
@@ -79,6 +92,7 @@ function Gladdy:GetSpecSpells()
         [GetSpellInfo(34413)] = L["Assassination"],     -- Mutilate
         [GetSpellInfo(13750)] = L["Combat"],            -- Adrenaline Rush
         [GetSpellInfo(14185)] = L["Subtlety"],          -- Preparation
+        [GetSpellInfo(16511)] = L["Subtlety"],          -- Hemorrhage
         [GetSpellInfo(36554)] = L["Subtlety"],          -- Shadowstep
 
         -- SHAMAN
@@ -99,6 +113,5 @@ function Gladdy:GetSpecSpells()
         [GetSpellInfo(30335)] = L["Fury"],              -- Bloodthirst
         [GetSpellInfo(12809)] = L["Protection"],        -- Concussion Blow
         [GetSpellInfo(30022)] = L["Protection"],        -- Devastation
-        [GetSpellInfo(12975)] = L["Protection"],        -- Last Stand
     }
 end


### PR DESCRIPTION
This adds the old trinket keybinds back, for servers that lack support, so players can manually trigger trinkets.
Additionally, it compares GUIDs in lowercase for some servers with "broken" trinket support
